### PR TITLE
Patch executor with supported image

### DIFF
--- a/src/prisma-cloud-scan.yml
+++ b/src/prisma-cloud-scan.yml
@@ -527,9 +527,11 @@ executors:
   default:
     description: |
             This executor is defined to be used for Prisma Cloud IaC Scan.
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
   compute:
     description: |
             Defines the working directory for Prisma Compute Scans.
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     working_directory: /tmp/twistlock-scan


### PR DESCRIPTION
## Description

See:
https://circleci.com/blog/ubuntu-14-16-image-deprecation/
and
https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/



## Motivation and Context

Brownouts will occur for users of this orb this month, unless this can be patched.

## How Has This Been Tested?

It hasn't.  I can't even use this orb because it only works on Prisma SaaS, not hosted envs.  It'd be really nice if you maintained one I can use, though.

## Screenshots (if appropriate)

N/A

## Types of changes

Compliance change

## Checklist


- [X ] I have updated the documentation accordingly. (no changes)
- [X ] I have read the **CONTRIBUTING** document.
- [X ] I have added tests to cover my changes if appropriate.
- [X ] All new and existing tests passed.
